### PR TITLE
feat: 카카오톡 수신 메시지 post 요청 추가

### DIFF
--- a/.github/workflows/ts-lint.yml
+++ b/.github/workflows/ts-lint.yml
@@ -47,7 +47,4 @@ jobs:
         run: pnpm install
 
       - name: Run Biome Lint
-        run: pnpm lint
-
-      - name: Run Biome Format Check
-        run: pnpm format --check
+        run: pnpm biome ci --formatter-enabled=false --organize-imports-enabled=false .

--- a/.github/workflows/ts-styles.yml
+++ b/.github/workflows/ts-styles.yml
@@ -47,7 +47,7 @@ jobs:
         run: pnpm install
 
       - name: Run Biome Format Check
-        run: pnpm format --check
+        run: pnpm biome ci --linter-enabled=false .
 
   biome-import-sort:
     runs-on: ubuntu-latest
@@ -70,4 +70,4 @@ jobs:
         run: pnpm install
 
       - name: Run Biome Import Sort Check
-        run: pnpm biome check --organize-imports-enabled=true --formatter-enabled=false --linter-enabled=false
+        run: pnpm biome ci --organize-imports-enabled=true --formatter-enabled=false --linter-enabled=false

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,9 @@ COPY package.json pnpm-lock.yaml* ./
 # 의존성 설치
 RUN pnpm install --frozen-lockfile
 
+# Playwright 브라우저 설치
+RUN pnpm exec playwright install
+
 # 소스 코드 복사
 COPY . .
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,26 +1,11 @@
-# Node.js 18 Alpine 이미지 사용
-FROM node:18-alpine
+# Debian 기반 이미지 사용
+FROM node:20-bookworm
 
 # 작업 디렉토리 설정
 WORKDIR /app
 
-# 시스템 패키지 업데이트 및 Playwright 의존성 설치
-RUN apk add --no-cache \
-    chromium \
-    nss \
-    freetype \
-    freetype-dev \
-    harfbuzz \
-    ca-certificates \
-    ttf-freefont \
-    && rm -rf /var/cache/apk/*
-
-# Playwright 환경 변수 설정
-ENV PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
-ENV PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH=/usr/bin/chromium-browser
-
 # pnpm 설치
-RUN npm install -g pnpm
+RUN corepack enable && corepack prepare pnpm@latest --activate
 
 # package.json과 pnpm-lock.yaml 복사
 COPY package.json pnpm-lock.yaml* ./
@@ -28,8 +13,8 @@ COPY package.json pnpm-lock.yaml* ./
 # 의존성 설치
 RUN pnpm install --frozen-lockfile
 
-# Playwright 브라우저 설치
-RUN pnpm exec playwright install
+# Playwright 브라우저 및 시스템 의존성 설치
+RUN pnpm exec playwright install --with-deps chromium
 
 # 소스 코드 복사
 COPY . .

--- a/README.md
+++ b/README.md
@@ -61,20 +61,70 @@ src/
 
 ### Docker 환경
 
+#### 환경 변수 설정
+
+Docker 실행 전에 카카오톡 로그인 정보를 환경 변수로 설정해야 합니다:
+
+```bash
+# 환경 변수 설정 (터미널에서)
+export KAKAO_LOGIN_ID="your_kakao_id"
+export KAKAO_LOGIN_PASSWORD="your_kakao_password"
+
+# 또는 .env 파일 생성
+echo "KAKAO_LOGIN_ID=your_kakao_id" > .env
+echo "KAKAO_LOGIN_PASSWORD=your_kakao_password" >> .env
+```
+
+#### Docker Compose 사용 (권장)
+
+1. **서비스 시작**
+   ```bash
+   docker compose up -d
+   ```
+
+2. **서비스 상태 확인**
+   ```bash
+   docker compose ps
+   ```
+
+3. **로그 확인**
+   ```bash
+   docker compose logs -f csmart-kakaotalk
+   ```
+
+4. **헬스체크 확인**
+   ```bash
+   curl http://localhost:3000/api/health
+   ```
+
+5. **서비스 중지**
+   ```bash
+   docker compose down
+   ```
+
+#### 개별 Docker 명령어
+
 1. **Docker 이미지 빌드**
    ```bash
-   pnpm docker:build
+   docker build -t csmart-kakaotalk .
    ```
 
 2. **Docker 컨테이너 실행**
    ```bash
-   pnpm docker:run
+   docker run -d \
+     --name csmart-kakaotalk-server \
+     -p 3000:3000 \
+     -e KAKAO_LOGIN_ID="your_kakao_id" \
+     -e KAKAO_LOGIN_PASSWORD="your_kakao_password" \
+     -v $(pwd)/logs:/app/logs \
+     csmart-kakaotalk
    ```
 
-3. **Docker Compose 사용**
-   ```bash
-   docker-compose up -d
-   ```
+#### 중요 사항
+
+- **로그인 세션 유지**: Docker 시작 시 한 번만 카카오톡에 로그인하고, 이후 메시지 전송 시에는 로그인 없이 기존 세션을 재사용합니다.
+- **헬스체크**: `/api/health` 엔드포인트에서 KakaoTalk 서비스의 로그인 상태를 확인할 수 있습니다.
+- **로그 확인**: `./logs/` 디렉토리에서 애플리케이션 로그를 확인할 수 있습니다.
 
 ## API 엔드포인트
 
@@ -156,13 +206,28 @@ curl -X POST http://localhost:3000/api/message/send \
 
 ## 환경 변수
 
-| 변수명 | 설명 | 기본값 |
-|--------|------|--------|
-| `NODE_ENV` | 실행 환경 | `development` |
-| `PORT` | 서버 포트 | `3000` |
-| `LOG_LEVEL` | 로그 레벨 | `info` |
-| `USER_INFO_SERVER_URL` | 사용자 정보 전송 서버 URL | `http://localhost:8080/api/users` |
-| `USER_INFO_SERVER_TIMEOUT` | 서버 연결 타임아웃 (ms) | `5000` |
+| 변수명 | 설명 | 기본값 | 필수 |
+|--------|------|--------|------|
+| `NODE_ENV` | 실행 환경 | `development` | ❌ |
+| `PORT` | 서버 포트 | `3000` | ❌ |
+| `LOG_LEVEL` | 로그 레벨 | `info` | ❌ |
+| `KAKAO_LOGIN_ID` | 카카오톡 로그인 ID | - | ✅ |
+| `KAKAO_LOGIN_PASSWORD` | 카카오톡 로그인 비밀번호 | - | ✅ |
+| `USER_INFO_SERVER_URL` | 사용자 정보 전송 서버 URL | `http://localhost:8080/api/users` | ❌ |
+| `USER_INFO_SERVER_TIMEOUT` | 서버 연결 타임아웃 (ms) | `5000` | ❌ |
+
+### 환경 변수 설정 예시
+
+```bash
+# .env 파일
+NODE_ENV=production
+PORT=3000
+LOG_LEVEL=info
+KAKAO_LOGIN_ID=your_kakao_id
+KAKAO_LOGIN_PASSWORD=your_kakao_password
+USER_INFO_SERVER_URL=http://your-server.com/api/users
+USER_INFO_SERVER_TIMEOUT=5000
+```
 
 ## 개발 가이드
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 ## 주요 기능
 
 - **카카오톡 챗봇 스킬**: 카카오톡 메시지 수신 시 알림 받기
+- **사용자 정보 전송**: 챗봇에서 받은 사용자 정보를 외부 서버로 POST 요청
 - **메시지 자동 전송**: POST 요청으로 메시지 내용을 받아 Playwright를 통해 카카오톡 전송
 - **Docker 지원**: 컨테이너화된 배포 환경
 
@@ -28,7 +29,8 @@ src/
 │   ├── message.ts          # 메시지 전송 엔드포인트
 │   └── health.ts           # 헬스체크 엔드포인트
 ├── services/               # 비즈니스 로직
-│   └── kakaotalk.service.ts # 카카오톡 서비스
+│   ├── kakaotalk.service.ts # 카카오톡 자동화 서비스
+│   └── user-info.service.ts # 사용자 정보 전송 서비스
 └── utils/                  # 유틸리티
     └── logger.ts           # 로깅 설정
 ```
@@ -79,12 +81,66 @@ src/
 ### 헬스체크
 - `GET /api/health` - 서버 상태 확인
 
+### 챗봇 스킬
+- `POST /api/chatbot/skill` - 카카오톡 챗봇 스킬 요청 처리
+- `GET /api/chatbot/test-connection` - 사용자 정보 서버 연결 테스트
+- `POST /api/chatbot/notifications/setup` - 알림 설정
+
 ### 메시지 전송
 - `POST /api/message/send` - 카카오톡 메시지 전송
 - `GET /api/message/status/:messageId` - 메시지 전송 상태 확인
 - `GET /api/message/history` - 메시지 전송 이력 조회
 
 ## 사용 예시
+
+### 챗봇 스킬 요청 (카카오톡에서 자동 호출)
+
+카카오톡 챗봇에서 사용자가 메시지를 보내면 다음과 같은 JSON이 서버로 전송됩니다:
+
+```json
+{
+  "intent": {
+    "id": "l4mw9l01x4kul611vtly1w9b",
+    "name": "블록 이름"
+  },
+  "userRequest": {
+    "timezone": "Asia/Seoul",
+    "params": {
+      "ignoreMe": "true"
+    },
+    "block": {
+      "id": "l4mw9l01x4kul611vtly1w9b",
+      "name": "블록 이름"
+    },
+    "utterance": "발화 내용",
+    "lang": null,
+    "user": {
+      "id": "363512",
+      "type": "accountId",
+      "properties": {}
+    }
+  },
+  "bot": {
+    "id": "68cbb775539054197042f1ab",
+    "name": "봇 이름"
+  },
+  "action": {
+    "name": "kjjj3jtdi6",
+    "clientExtra": null,
+    "params": {},
+    "id": "nhx57fsbrkdbh8yg5ccdyb88",
+    "detailParams": {}
+  }
+}
+```
+
+서버는 이 정보를 받아서 사용자 정보를 외부 서버로 POST 요청합니다. 현재는 시뮬레이션 모드로 로그에만 출력됩니다.
+
+### 사용자 정보 서버 연결 테스트
+
+```bash
+curl -X GET http://localhost:3000/api/chatbot/test-connection
+```
 
 ### 메시지 전송 요청
 
@@ -104,6 +160,9 @@ curl -X POST http://localhost:3000/api/message/send \
 |--------|------|--------|
 | `NODE_ENV` | 실행 환경 | `development` |
 | `PORT` | 서버 포트 | `3000` |
+| `LOG_LEVEL` | 로그 레벨 | `info` |
+| `USER_INFO_SERVER_URL` | 사용자 정보 전송 서버 URL | `http://localhost:8080/api/users` |
+| `USER_INFO_SERVER_TIMEOUT` | 서버 연결 타임아웃 (ms) | `5000` |
 
 ## 개발 가이드
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Docker 실행 전에 필수 환경 변수를 설정해야 합니다:
 # 카카오톡 로그인 정보 (필수)
 export KAKAO_LOGIN_ID="your_kakao_id"
 export KAKAO_LOGIN_PASSWORD="your_kakao_password"
+export BACKEND_SERVER_URL="http://your-server.com/api/users" # 추후 api endpoint 설정 필요
 ```
 
 **선택적 환경 변수:**
@@ -81,7 +82,6 @@ export PORT="3000"
 export LOG_LEVEL="info"
 
 # 외부 서버 설정
-export BACKEND_SERVER_URL="http://your-server.com/api/users"
 export USER_INFO_SERVER_TIMEOUT="5000"
 ```
 
@@ -143,6 +143,7 @@ EOF
      -p 3000:3000 \
      -e KAKAO_LOGIN_ID="your_kakao_id" \
      -e KAKAO_LOGIN_PASSWORD="your_kakao_password" \
+     -e BACKEND_SERVER_URL="http://your-server.com/api/users" \
      -v $(pwd)/logs:/app/logs \
      csmart-kakaotalk
    ```

--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ curl -X POST http://localhost:3000/api/message/send \
 | `LOG_LEVEL` | 로그 레벨 | `info` | ❌ |
 | `KAKAO_LOGIN_ID` | 카카오톡 로그인 ID | - | ✅ |
 | `KAKAO_LOGIN_PASSWORD` | 카카오톡 로그인 비밀번호 | - | ✅ |
-| `USER_INFO_SERVER_URL` | 사용자 정보 전송 서버 URL | `http://localhost:8080/api/users` | ❌ |
+| `BACKEND_SERVER_URL` | 사용자 정보 전송 서버 URL | `http://localhost:8080/api/users` | ❌ |
 | `USER_INFO_SERVER_TIMEOUT` | 서버 연결 타임아웃 (ms) | `5000` | ❌ |
 
 ### 환경 변수 설정 예시
@@ -225,7 +225,7 @@ PORT=3000
 LOG_LEVEL=info
 KAKAO_LOGIN_ID=your_kakao_id
 KAKAO_LOGIN_PASSWORD=your_kakao_password
-USER_INFO_SERVER_URL=http://your-server.com/api/users
+BACKEND_SERVER_URL=http://your-server.com/api/users
 USER_INFO_SERVER_TIMEOUT=5000
 ```
 

--- a/README.md
+++ b/README.md
@@ -247,3 +247,96 @@ USER_INFO_SERVER_TIMEOUT=5000
 ## 라이선스
 
 MIT
+
+/api/message/chat-list
+{
+    "success": true,
+    "message": "카카오톡에서 채팅 목록을 성공적으로 가져와서 저장했습니다.",
+    "data": {
+        "id": "chatlist_1759641484321",
+        "savedAt": "2025-10-05T05:18:04.321Z",
+        "totalCount": 2,
+        "chatList": {
+            "items": [
+                {
+                    "talk_user": {
+                        "status_message": "",
+                        "active": true,
+                        "profile_image_url": "",
+                        "chat_id": "4952763873902355",
+                        "user_type": 0,
+                        "nickname": "임경빈",
+                        "original_profile_image_url": "",
+                        "id": "4952763873902355_tuser",
+                        "full_profile_image_url": ""
+                    },
+                    "last_seen_log_id": "3679609246841311233",
+                    "created_at": 1759574173000,
+                    "last_message": "테",
+                    "is_replied": false,
+                    "is_read": true,
+                    "unread_count": 0,
+                    "need_manager_confirm": false,
+                    "is_deleted": false,
+                    "updated_at": 1759580804000,
+                    "id": "4952763873902355",
+                    "assignee_id": 0,
+                    "last_log_id": "3679609246841311233",
+                    "is_done": false,
+                    "user_last_seen_log_id": "3679609246841311233",
+                    "version": 1759580804172,
+                    "last_log_send_at": 1759580804140,
+                    "is_blocked": false,
+                    "is_starred": false,
+                    "is_user_left": false,
+                    "profile_id": "_TcdTn",
+                    "encoded_profile_id": "_TcdTn",
+                    "ai_flag": false,
+                    "name": "임경빈",
+                    "chat_label_ids": [],
+                    "is_friend": true
+                },
+                {
+                    "talk_user": {
+                        "active": true,
+                        "profile_image_url": "",
+                        "chat_id": "4947898629963361",
+                        "user_type": 0,
+                        "nickname": "이성재",
+                        "original_profile_image_url": "",
+                        "id": "4947898629963361_tuser",
+                        "full_profile_image_url": ""
+                    },
+                    "last_seen_log_id": "3663531541889001093",
+                    "created_at": 1754822949000,
+                    "last_message": "http://pf.kakao.com/_tzzAn\r\n\r\n\r\n\r\n안녕하세요, 관리는 제 개별 카카오톡 채널을 통해 진행될 예정입니다. 채널 추가 후 메세지 한번 남겨주시기 바랍니다.",
+                    "is_replied": true,
+                    "is_read": true,
+                    "unread_count": 0,
+                    "need_manager_confirm": false,
+                    "is_deleted": false,
+                    "updated_at": 1757664192000,
+                    "id": "4947898629963361",
+                    "assignee_id": 0,
+                    "last_log_id": "3663531541889001093",
+                    "is_done": false,
+                    "user_last_seen_log_id": "3663531541889001093",
+                    "version": 1757671152143,
+                    "last_log_send_at": 1757664192355,
+                    "is_blocked": false,
+                    "is_starred": false,
+                    "is_user_left": false,
+                    "profile_id": "_TcdTn",
+                    "encoded_profile_id": "_TcdTn",
+                    "ai_flag": false,
+                    "name": "이성재",
+                    "chat_label_ids": [],
+                    "is_friend": false,
+                    "add_msg_layer_status": "close",
+                    "check_add_friend_message": true
+                }
+            ],
+            "has_next": false
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 - **카카오톡 챗봇 스킬**: 카카오톡 메시지 수신 시 알림 받기
 - **사용자 정보 전송**: 챗봇에서 받은 사용자 정보를 외부 서버로 POST 요청
 - **메시지 자동 전송**: POST 요청으로 메시지 내용을 받아 Playwright를 통해 카카오톡 전송
+- **채팅 목록 관리**: 카카오톡에서 채팅 목록을 가져와서 자동 저장
 - **Docker 지원**: 컨테이너화된 배포 환경
 
 ## 기술 스택
@@ -63,16 +64,42 @@ src/
 
 #### 환경 변수 설정
 
-Docker 실행 전에 카카오톡 로그인 정보를 환경 변수로 설정해야 합니다:
+Docker 실행 전에 필수 환경 변수를 설정해야 합니다:
 
+**필수 환경 변수:**
 ```bash
-# 환경 변수 설정 (터미널에서)
+# 카카오톡 로그인 정보 (필수)
 export KAKAO_LOGIN_ID="your_kakao_id"
 export KAKAO_LOGIN_PASSWORD="your_kakao_password"
+```
 
-# 또는 .env 파일 생성
-echo "KAKAO_LOGIN_ID=your_kakao_id" > .env
-echo "KAKAO_LOGIN_PASSWORD=your_kakao_password" >> .env
+**선택적 환경 변수:**
+```bash
+# 서버 설정
+export NODE_ENV="production"
+export PORT="3000"
+export LOG_LEVEL="info"
+
+# 외부 서버 설정
+export BACKEND_SERVER_URL="http://your-server.com/api/users"
+export USER_INFO_SERVER_TIMEOUT="5000"
+```
+
+**또는 .env 파일 생성:**
+```bash
+# .env 파일 생성
+cat > .env << EOF
+# 필수 환경 변수
+KAKAO_LOGIN_ID=your_kakao_id
+KAKAO_LOGIN_PASSWORD=your_kakao_password
+
+# 선택적 환경 변수
+NODE_ENV=production
+PORT=3000
+LOG_LEVEL=info
+BACKEND_SERVER_URL=http://your-server.com/api/users
+USER_INFO_SERVER_TIMEOUT=5000
+EOF
 ```
 
 #### Docker Compose 사용 (권장)
@@ -125,25 +152,49 @@ echo "KAKAO_LOGIN_PASSWORD=your_kakao_password" >> .env
 - **로그인 세션 유지**: Docker 시작 시 한 번만 카카오톡에 로그인하고, 이후 메시지 전송 시에는 로그인 없이 기존 세션을 재사용합니다.
 - **헬스체크**: `/api/health` 엔드포인트에서 KakaoTalk 서비스의 로그인 상태를 확인할 수 있습니다.
 - **로그 확인**: `./logs/` 디렉토리에서 애플리케이션 로그를 확인할 수 있습니다.
+- **Playwright 브라우저**: Docker 이미지에 Playwright 브라우저가 자동으로 설치됩니다.
 
 ## API 엔드포인트
 
-### 헬스체크
-- `GET /api/health` - 서버 상태 확인
+### 1. 헬스체크
+- `GET /api/health` - 서버 상태 및 KakaoTalk 서비스 상태 확인
 
-### 챗봇 스킬
+### 2. 챗봇 스킬
 - `POST /api/chatbot/skill` - 카카오톡 챗봇 스킬 요청 처리
 - `GET /api/chatbot/test-connection` - 사용자 정보 서버 연결 테스트
-- `POST /api/chatbot/notifications/setup` - 알림 설정
 
-### 메시지 전송
+### 3. 메시지 전송
 - `POST /api/message/send` - 카카오톡 메시지 전송
 - `GET /api/message/status/:messageId` - 메시지 전송 상태 확인
-- `GET /api/message/history` - 메시지 전송 이력 조회
+
+### 4. 채팅 목록 관리
+- `POST /api/message/chat-list` - 카카오톡에서 채팅 목록 가져오기 및 자동 저장
 
 ## 사용 예시
 
-### 챗봇 스킬 요청 (카카오톡에서 자동 호출)
+### 1. 헬스체크 확인
+
+```bash
+curl -X GET http://localhost:3000/api/health
+```
+
+**응답 예시:**
+```json
+{
+  "uptime": 123.456,
+  "message": "서버가 정상적으로 작동 중입니다.",
+  "timestamp": "2025-01-05T05:18:04.321Z",
+  "environment": "production",
+  "services": {
+    "kakaoTalk": {
+      "isReady": true,
+      "isLoggedIn": true
+    }
+  }
+}
+```
+
+### 2. 챗봇 스킬 요청 (카카오톡에서 자동 호출)
 
 카카오톡 챗봇에서 사용자가 메시지를 보내면 다음과 같은 JSON이 서버로 전송됩니다:
 
@@ -184,15 +235,38 @@ echo "KAKAO_LOGIN_PASSWORD=your_kakao_password" >> .env
 }
 ```
 
-서버는 이 정보를 받아서 사용자 정보를 외부 서버로 POST 요청합니다. 현재는 시뮬레이션 모드로 로그에만 출력됩니다.
+**응답 예시:**
+```json
+{
+  "version": "2.0",
+  "template": {
+    "outputs": [
+      {
+        "simpleText": {
+          "text": "메시지를 받았습니다.\n받은 메시지: 발화 내용\n보낸사람: 임경빈"
+        }
+      }
+    ]
+  }
+}
+```
 
-### 사용자 정보 서버 연결 테스트
+### 3. 사용자 정보 서버 연결 테스트
 
 ```bash
 curl -X GET http://localhost:3000/api/chatbot/test-connection
 ```
 
-### 메시지 전송 요청
+**응답 예시:**
+```json
+{
+  "success": true,
+  "message": "사용자 정보 서버 연결 성공",
+  "serverUrl": "http://localhost:8080/api/users"
+}
+```
+
+### 4. 메시지 전송 요청
 
 ```bash
 curl -X POST http://localhost:3000/api/message/send \
@@ -200,8 +274,99 @@ curl -X POST http://localhost:3000/api/message/send \
   -d '{
     "recipient": "친구이름",
     "message": "안녕하세요! 자동으로 전송된 메시지입니다.",
-    "messageType": "text"
+    "messageType": "text",
+    "chatId": "4952763873902355"
   }'
+```
+
+**응답 예시:**
+```json
+{
+  "success": true,
+  "message": "메시지가 성공적으로 전송되었습니다.",
+  "result": {
+    "messageId": "msg_1759641484321",
+    "sentAt": "2025-01-05T05:18:04.321Z",
+    "status": "sent"
+  }
+}
+```
+
+### 5. 메시지 전송 상태 확인
+
+```bash
+curl -X GET http://localhost:3000/api/message/status/msg_1759641484321
+```
+
+**응답 예시:**
+```json
+{
+  "messageId": "msg_1759641484321",
+  "status": "sent",
+  "timestamp": "2025-01-05T05:18:04.321Z"
+}
+```
+
+### 6. 채팅 목록 가져오기 및 자동 저장
+
+```bash
+curl -X POST http://localhost:3000/api/message/chat-list
+```
+
+**응답 예시:**
+```json
+{
+  "success": true,
+  "message": "카카오톡에서 채팅 목록을 성공적으로 가져와서 저장했습니다.",
+  "data": {
+    "id": "chatlist_1759641484321",
+    "savedAt": "2025-01-05T05:18:04.321Z",
+    "totalCount": 2,
+    "chatList": {
+      "items": [
+        {
+          "talk_user": {
+            "status_message": "",
+            "active": true,
+            "profile_image_url": "",
+            "chat_id": "4952763873902355",
+            "user_type": 0,
+            "nickname": "임경빈",
+            "original_profile_image_url": "",
+            "id": "4952763873902355_tuser",
+            "full_profile_image_url": ""
+          },
+          "last_seen_log_id": "3679609246841311233",
+          "created_at": 1759574173000,
+          "last_message": "테",
+          "is_replied": false,
+          "is_read": true,
+          "unread_count": 0,
+          "need_manager_confirm": false,
+          "is_deleted": false,
+          "updated_at": 1759580804000,
+          "id": "4952763873902355",
+          "assignee_id": 0,
+          "last_log_id": "3679609246841311233",
+          "is_done": false,
+          "user_last_seen_log_id": "3679609246841311233",
+          "version": 1759580804172,
+          "last_log_send_at": 1759580804140,
+          "is_blocked": false,
+          "is_starred": false,
+          "is_user_left": false,
+          "profile_id": "_TcdTn",
+          "encoded_profile_id": "_TcdTn",
+          "ai_flag": false,
+          "name": "임경빈",
+          "chat_label_ids": [],
+          "is_friend": true
+        }
+      ],
+      "has_next": false
+    }
+  }
+}
 ```
 
 ## 환경 변수
@@ -229,6 +394,29 @@ BACKEND_SERVER_URL=http://your-server.com/api/users
 USER_INFO_SERVER_TIMEOUT=5000
 ```
 
+### Docker Compose 환경 변수 설정
+
+`docker-compose.yml`에서 환경 변수를 설정할 수도 있습니다:
+
+```yaml
+version: '3.8'
+services:
+  csmart-kakaotalk:
+    build: .
+    ports:
+      - "3000:3000"
+    environment:
+      - NODE_ENV=production
+      - PORT=3000
+      - LOG_LEVEL=info
+      - KAKAO_LOGIN_ID=${KAKAO_LOGIN_ID}
+      - KAKAO_LOGIN_PASSWORD=${KAKAO_LOGIN_PASSWORD}
+      - BACKEND_SERVER_URL=${BACKEND_SERVER_URL:-http://localhost:8080/api/users}
+      - USER_INFO_SERVER_TIMEOUT=${USER_INFO_SERVER_TIMEOUT:-5000}
+    volumes:
+      - ./logs:/app/logs
+```
+
 ## 개발 가이드
 
 ### 코드 스타일
@@ -247,96 +435,3 @@ USER_INFO_SERVER_TIMEOUT=5000
 ## 라이선스
 
 MIT
-
-/api/message/chat-list
-{
-    "success": true,
-    "message": "카카오톡에서 채팅 목록을 성공적으로 가져와서 저장했습니다.",
-    "data": {
-        "id": "chatlist_1759641484321",
-        "savedAt": "2025-10-05T05:18:04.321Z",
-        "totalCount": 2,
-        "chatList": {
-            "items": [
-                {
-                    "talk_user": {
-                        "status_message": "",
-                        "active": true,
-                        "profile_image_url": "",
-                        "chat_id": "4952763873902355",
-                        "user_type": 0,
-                        "nickname": "임경빈",
-                        "original_profile_image_url": "",
-                        "id": "4952763873902355_tuser",
-                        "full_profile_image_url": ""
-                    },
-                    "last_seen_log_id": "3679609246841311233",
-                    "created_at": 1759574173000,
-                    "last_message": "테",
-                    "is_replied": false,
-                    "is_read": true,
-                    "unread_count": 0,
-                    "need_manager_confirm": false,
-                    "is_deleted": false,
-                    "updated_at": 1759580804000,
-                    "id": "4952763873902355",
-                    "assignee_id": 0,
-                    "last_log_id": "3679609246841311233",
-                    "is_done": false,
-                    "user_last_seen_log_id": "3679609246841311233",
-                    "version": 1759580804172,
-                    "last_log_send_at": 1759580804140,
-                    "is_blocked": false,
-                    "is_starred": false,
-                    "is_user_left": false,
-                    "profile_id": "_TcdTn",
-                    "encoded_profile_id": "_TcdTn",
-                    "ai_flag": false,
-                    "name": "임경빈",
-                    "chat_label_ids": [],
-                    "is_friend": true
-                },
-                {
-                    "talk_user": {
-                        "active": true,
-                        "profile_image_url": "",
-                        "chat_id": "4947898629963361",
-                        "user_type": 0,
-                        "nickname": "이성재",
-                        "original_profile_image_url": "",
-                        "id": "4947898629963361_tuser",
-                        "full_profile_image_url": ""
-                    },
-                    "last_seen_log_id": "3663531541889001093",
-                    "created_at": 1754822949000,
-                    "last_message": "http://pf.kakao.com/_tzzAn\r\n\r\n\r\n\r\n안녕하세요, 관리는 제 개별 카카오톡 채널을 통해 진행될 예정입니다. 채널 추가 후 메세지 한번 남겨주시기 바랍니다.",
-                    "is_replied": true,
-                    "is_read": true,
-                    "unread_count": 0,
-                    "need_manager_confirm": false,
-                    "is_deleted": false,
-                    "updated_at": 1757664192000,
-                    "id": "4947898629963361",
-                    "assignee_id": 0,
-                    "last_log_id": "3663531541889001093",
-                    "is_done": false,
-                    "user_last_seen_log_id": "3663531541889001093",
-                    "version": 1757671152143,
-                    "last_log_send_at": 1757664192355,
-                    "is_blocked": false,
-                    "is_starred": false,
-                    "is_user_left": false,
-                    "profile_id": "_TcdTn",
-                    "encoded_profile_id": "_TcdTn",
-                    "ai_flag": false,
-                    "name": "이성재",
-                    "chat_label_ids": [],
-                    "is_friend": false,
-                    "add_msg_layer_status": "close",
-                    "check_add_friend_message": true
-                }
-            ],
-            "has_next": false
-        }
-    }
-}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
       - LOG_LEVEL=info
       - KAKAO_LOGIN_ID=${KAKAO_LOGIN_ID}
       - KAKAO_LOGIN_PASSWORD=${KAKAO_LOGIN_PASSWORD}
+      - BACKEND_SERVER_URL=${BACKEND_SERVER_URL}
     volumes:
       # 로그 디렉토리 마운트
       - ./logs:/app/logs

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,8 @@ services:
       - NODE_ENV=production
       - PORT=3000
       - LOG_LEVEL=info
+      - KAKAO_LOGIN_ID=${KAKAO_LOGIN_ID}
+      - KAKAO_LOGIN_PASSWORD=${KAKAO_LOGIN_PASSWORD}
     volumes:
       # 로그 디렉토리 마운트
       - ./logs:/app/logs

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,8 +3,9 @@ import dotenv from "dotenv";
 import express from "express";
 import helmet from "helmet";
 import { chatbotRouter } from "./routes/chatbot";
-import { healthRouter } from "./routes/health";
+import { healthRouter, setKakaoTalkService } from "./routes/health";
 import { messageRouter } from "./routes/message";
+import { KakaoTalkService } from "./services/kakaotalk.service";
 import { logger } from "./utils/logger";
 
 // 환경 변수 로드
@@ -12,6 +13,12 @@ dotenv.config();
 
 const app: express.Application = express();
 const PORT = process.env.PORT || 3000;
+
+// KakaoTalk 서비스 인스턴스 생성
+const kakaoTalkService = new KakaoTalkService();
+
+// 헬스체크 라우터에 KakaoTalk 서비스 설정
+setKakaoTalkService(kakaoTalkService);
 
 // 미들웨어 설정
 app.use(helmet());
@@ -59,10 +66,51 @@ app.use((err: Error, _req: express.Request, res: express.Response, _next: expres
   });
 });
 
+// 서버 시작 및 KakaoTalk 서비스 초기화
+const startServer = async () => {
+  try {
+    // KakaoTalk 서비스 초기화
+    logger.info("KakaoTalk 서비스 초기화 시작...");
+    const initResult = await kakaoTalkService.initialize();
+
+    if (!initResult.success) {
+      logger.error("KakaoTalk 서비스 초기화 실패:", initResult.error);
+      logger.warn("서버는 시작되지만 KakaoTalk 기능이 제한될 수 있습니다.");
+    } else {
+      logger.info("KakaoTalk 서비스 초기화 완료");
+    }
+
+    // 서버 시작
+    app.listen(PORT, () => {
+      logger.info(`서버가 포트 ${PORT}에서 실행 중입니다.`);
+      console.log(`🚀 서버가 http://localhost:${PORT}에서 실행 중입니다.`);
+
+      if (initResult.success) {
+        console.log("✅ KakaoTalk 서비스가 준비되었습니다.");
+      } else {
+        console.log("⚠️  KakaoTalk 서비스 초기화에 실패했습니다.");
+      }
+    });
+
+    // Graceful shutdown 처리
+    process.on("SIGINT", async () => {
+      logger.info("서버 종료 신호를 받았습니다. 정리 작업을 시작합니다...");
+      await kakaoTalkService.close();
+      process.exit(0);
+    });
+
+    process.on("SIGTERM", async () => {
+      logger.info("서버 종료 신호를 받았습니다. 정리 작업을 시작합니다...");
+      await kakaoTalkService.close();
+      process.exit(0);
+    });
+  } catch (error) {
+    logger.error("서버 시작 중 오류 발생:", error);
+    process.exit(1);
+  }
+};
+
 // 서버 시작
-app.listen(PORT, () => {
-  logger.info(`서버가 포트 ${PORT}에서 실행 중입니다.`);
-  console.log(`🚀 서버가 http://localhost:${PORT}에서 실행 중입니다.`);
-});
+startServer();
 
 export default app;

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ import express from "express";
 import helmet from "helmet";
 import { chatbotRouter } from "./routes/chatbot";
 import { healthRouter, setKakaoTalkService } from "./routes/health";
-import { messageRouter } from "./routes/message";
+import { messageRouter, setKakaoTalkService as setMessageKakaoTalkService } from "./routes/message";
 import { KakaoTalkService } from "./services/kakaotalk.service";
 import { logger } from "./utils/logger";
 
@@ -19,6 +19,9 @@ const kakaoTalkService = new KakaoTalkService();
 
 // 헬스체크 라우터에 KakaoTalk 서비스 설정
 setKakaoTalkService(kakaoTalkService);
+
+// 메시지 라우터에 KakaoTalk 서비스 설정
+setMessageKakaoTalkService(kakaoTalkService);
 
 // 미들웨어 설정
 app.use(helmet());

--- a/src/routes/chatbot.ts
+++ b/src/routes/chatbot.ts
@@ -144,34 +144,4 @@ router.get("/test-connection", async (_req, res) => {
   }
 });
 
-/**
- * 카카오톡 알림 설정 엔드포인트
- */
-router.post("/notifications/setup", (req, res) => {
-  try {
-    const { webhookUrl, userId } = req.body;
-
-    if (!webhookUrl || !userId) {
-      res.status(400).json({
-        error: "webhookUrl과 userId는 필수입니다.",
-      });
-      return;
-    }
-
-    // 알림 설정 로직 구현
-    logger.info("알림 설정 요청", { webhookUrl, userId });
-
-    res.json({
-      message: "알림이 성공적으로 설정되었습니다.",
-      webhookUrl,
-      userId,
-    });
-  } catch (error) {
-    logger.error("알림 설정 중 오류 발생:", error);
-    res.status(500).json({
-      error: "알림 설정 중 오류가 발생했습니다.",
-    });
-  }
-});
-
 export { router as chatbotRouter };

--- a/src/routes/chatbot.ts
+++ b/src/routes/chatbot.ts
@@ -126,13 +126,13 @@ router.get("/test-connection", async (_req, res) => {
       res.json({
         success: true,
         message: "사용자 정보 서버 연결 성공",
-        serverUrl: process.env.USER_INFO_SERVER_URL || "http://localhost:8080/api/users",
+        serverUrl: process.env.BACKEND_SERVER_URL || "http://localhost:8080/api/users",
       });
     } else {
       res.status(503).json({
         success: false,
         message: "사용자 정보 서버 연결 실패",
-        serverUrl: process.env.USER_INFO_SERVER_URL || "http://localhost:8080/api/users",
+        serverUrl: process.env.BACKEND_SERVER_URL || "http://localhost:8080/api/users",
       });
     }
   } catch (error) {

--- a/src/routes/chatbot.ts
+++ b/src/routes/chatbot.ts
@@ -1,21 +1,44 @@
 import { Router } from "express";
 import { z } from "zod";
+import { UserInfoService } from "../services/user-info.service";
 import { logger } from "../utils/logger";
 
 const router: Router = Router();
 
+// 사용자 정보 전송 서비스 인스턴스
+const userInfoService = new UserInfoService();
+
 // 카카오톡 챗봇 스킬 요청 스키마
 const chatbotSkillSchema = z.object({
+  intent: z.object({
+    id: z.string(),
+    name: z.string(),
+  }),
   userRequest: z.object({
+    timezone: z.string().optional(),
+    params: z.record(z.any()).optional(),
+    block: z.object({
+      id: z.string(),
+      name: z.string(),
+    }),
     utterance: z.string(),
+    lang: z.string().nullable().optional(),
     user: z.object({
       id: z.string(),
       type: z.string(),
+      properties: z.record(z.any()).optional(),
     }),
+  }),
+  bot: z.object({
+    id: z.string(),
+    name: z.string(),
   }),
   action: z.object({
     name: z.string(),
-    clientExtra: z.any().optional(),
+    clientExtra: z.any().nullable().optional(),
+    params: z.record(z.any()).optional(),
+    id: z.string(),
+    detailParams: z.record(z.any()).optional(),
   }),
 });
 
@@ -32,19 +55,41 @@ router.post("/skill", async (req, res) => {
       userId: validatedData.userRequest.user.id,
       utterance: validatedData.userRequest.utterance,
       actionName: validatedData.action.name,
+      intentName: validatedData.intent.name,
+      botName: validatedData.bot.name,
     });
 
-    // 여기에 실제 알림 로직 구현
-    // 예: 웹훅 전송, 데이터베이스 저장, 다른 서비스 호출 등
+    // 사용자 정보를 외부 서버로 전송
+    try {
+      const userInfo = UserInfoService.convertFromChatbotData(validatedData);
+      const sendSuccess = await userInfoService.sendUserInfo(userInfo);
+
+      if (sendSuccess) {
+        logger.info("사용자 정보 전송 완료", {
+          userId: userInfo.userId,
+          userName: userInfo.userName,
+        });
+      } else {
+        logger.warn("사용자 정보 전송 실패", {
+          userId: userInfo.userId,
+        });
+      }
+    } catch (userInfoError) {
+      logger.error("사용자 정보 전송 중 오류 발생", {
+        userId: validatedData.userRequest.user.id,
+        error: userInfoError instanceof Error ? userInfoError.message : "Unknown error",
+      });
+    }
 
     // 카카오톡 챗봇 응답
+    const userName = validatedData.userRequest.user.properties?.name || "임경빈";
     const response = {
       version: "2.0",
       template: {
         outputs: [
           {
             simpleText: {
-              text: `메시지를 받았습니다: "${validatedData.userRequest.utterance}"`,
+              text: `메시지를 받았습니다.\n받은 메시지: ${validatedData.userRequest.utterance}\n보낸사람: ${userName}`,
             },
           },
         ],
@@ -66,6 +111,35 @@ router.post("/skill", async (req, res) => {
     res.status(500).json({
       error: "Internal server error",
       message: "챗봇 스킬 처리 중 오류가 발생했습니다.",
+    });
+  }
+});
+
+/**
+ * 사용자 정보 서버 연결 테스트 엔드포인트
+ */
+router.get("/test-connection", async (_req, res) => {
+  try {
+    const isConnected = await userInfoService.testConnection();
+
+    if (isConnected) {
+      res.json({
+        success: true,
+        message: "사용자 정보 서버 연결 성공",
+        serverUrl: process.env.USER_INFO_SERVER_URL || "http://localhost:8080/api/users",
+      });
+    } else {
+      res.status(503).json({
+        success: false,
+        message: "사용자 정보 서버 연결 실패",
+        serverUrl: process.env.USER_INFO_SERVER_URL || "http://localhost:8080/api/users",
+      });
+    }
+  } catch (error) {
+    logger.error("서버 연결 테스트 중 오류 발생:", error);
+    res.status(500).json({
+      success: false,
+      error: "서버 연결 테스트 중 오류가 발생했습니다.",
     });
   }
 });

--- a/src/routes/health.ts
+++ b/src/routes/health.ts
@@ -1,22 +1,54 @@
 import { Router } from "express";
+import type { KakaoTalkService } from "../services/kakaotalk.service";
 import { logger } from "../utils/logger";
 
 const router: Router = Router();
+
+// KakaoTalk 서비스 인스턴스 (실제로는 전역에서 가져와야 함)
+let kakaoTalkService: KakaoTalkService | null = null;
+
+/**
+ * KakaoTalk 서비스 인스턴스 설정 (index.ts에서 호출)
+ */
+export const setKakaoTalkService = (service: KakaoTalkService) => {
+  kakaoTalkService = service;
+};
 
 /**
  * 서버 상태 확인 엔드포인트
  */
 router.get("/", (req, res) => {
   try {
+    const kakaoTalkStatus = kakaoTalkService
+      ? {
+          isReady: kakaoTalkService.isServiceReady(),
+          isLoggedIn: kakaoTalkService.isServiceReady(),
+        }
+      : {
+          isReady: false,
+          isLoggedIn: false,
+          error: "KakaoTalk 서비스가 초기화되지 않았습니다.",
+        };
+
     const healthCheck = {
       uptime: process.uptime(),
       message: "서버가 정상적으로 작동 중입니다.",
       timestamp: new Date().toISOString(),
       environment: process.env.NODE_ENV || "development",
+      services: {
+        kakaoTalk: kakaoTalkStatus,
+      },
     };
 
-    logger.info("헬스 체크 요청", { ip: req.ip });
-    res.status(200).json(healthCheck);
+    // KakaoTalk 서비스가 준비되지 않은 경우 503 상태 반환
+    const statusCode = kakaoTalkStatus.isReady ? 200 : 503;
+
+    logger.info("헬스 체크 요청", {
+      ip: req.ip,
+      kakaoTalkReady: kakaoTalkStatus.isReady,
+    });
+
+    res.status(statusCode).json(healthCheck);
   } catch (error) {
     logger.error("헬스 체크 실패:", error);
     res.status(503).json({

--- a/src/routes/message.ts
+++ b/src/routes/message.ts
@@ -1,10 +1,18 @@
 import { Router } from "express";
 import { z } from "zod";
-import { KakaoTalkService } from "../services/kakaotalk.service";
+import type { KakaoTalkService } from "../services/kakaotalk.service";
 import { logger } from "../utils/logger";
 
 const router: Router = Router();
-const kakaoTalkService = new KakaoTalkService();
+let kakaoTalkService: KakaoTalkService;
+
+/**
+ * KakaoTalkService 인스턴스 설정 함수
+ * @param service KakaoTalkService 인스턴스
+ */
+export const setKakaoTalkService = (service: KakaoTalkService): void => {
+  kakaoTalkService = service;
+};
 
 // 메시지 전송 요청 스키마
 const messageSchema = z.object({

--- a/src/services/kakaotalk.service.ts
+++ b/src/services/kakaotalk.service.ts
@@ -94,7 +94,7 @@ export class KakaoTalkService {
   private async initBrowser(): Promise<Browser> {
     if (!this.browser) {
       this.browser = await chromium.launch({
-        headless: false, // 디버깅을 위해 브라우저 창 표시
+        headless: true, // 디버깅을 위해 브라우저 창 표시
         args: [
           "--no-sandbox",
           "--disable-setuid-sandbox",

--- a/src/services/kakaotalk.service.ts
+++ b/src/services/kakaotalk.service.ts
@@ -107,6 +107,12 @@ export class KakaoTalkService {
           "--disable-gpu",
           "--disable-web-security",
           "--disable-features=VizDisplayCompositor",
+          "--disable-blink-features=AutomationControlled",
+          "--disable-extensions",
+          "--disable-plugins",
+          "--disable-images",
+          "--disable-javascript-harmony-shipping",
+          "--user-agent=Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
         ],
       });
 
@@ -129,6 +135,14 @@ export class KakaoTalkService {
 
       // 메인 페이지 생성
       this.mainPage = await this.browser.newPage();
+
+      // 페이지 설정
+      await this.mainPage.setViewportSize({ width: 1920, height: 1080 });
+      await this.mainPage.setExtraHTTPHeaders({
+        "Accept-Language": "ko-KR,ko;q=0.9,en;q=0.8,en-US;q=0.7",
+        Accept:
+          "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8",
+      });
 
       // 로그인 수행
       const loginSuccess = await this.loginToKakaoTalk(this.mainPage);

--- a/src/services/user-info.service.ts
+++ b/src/services/user-info.service.ts
@@ -1,3 +1,4 @@
+import axios, { type AxiosResponse } from "axios";
 import { logger } from "../utils/logger";
 
 // 사용자 정보 인터페이스
@@ -12,6 +13,12 @@ export interface UserInfo {
   actionName: string;
 }
 
+// 서버 응답 인터페이스
+interface UserInfoResponse {
+  success: boolean;
+  message?: string;
+}
+
 /**
  * 사용자 정보를 외부 서버로 전송하는 서비스
  */
@@ -21,7 +28,7 @@ export class UserInfoService {
 
   constructor() {
     // 환경변수에서 서버 URL과 타임아웃 설정
-    this.serverUrl = process.env.USER_INFO_SERVER_URL || "http://localhost:8080/api/users";
+    this.serverUrl = process.env.BACKEND_SERVER_URL || "http://localhost:8080/api/users";
     this.timeout = Number.parseInt(process.env.USER_INFO_SERVER_TIMEOUT || "5000", 10);
   }
 
@@ -51,18 +58,13 @@ export class UserInfoService {
       });
 
       // 실제 서버가 있다면 아래 코드를 사용
-      /*
-      const response: AxiosResponse<UserInfoResponse> = await axios.post(
-        this.serverUrl,
-        userInfo,
-        {
-          timeout: this.timeout,
-          headers: {
-            "Content-Type": "application/json",
-            "User-Agent": "CSmart-KakaoTalk/1.0.0",
-          },
-        }
-      );
+      const response: AxiosResponse<UserInfoResponse> = await axios.post(this.serverUrl, userInfo, {
+        timeout: this.timeout,
+        headers: {
+          "Content-Type": "application/json",
+          "User-Agent": "CSmart-KakaoTalk/1.0.0",
+        },
+      });
 
       if (response.data.success) {
         logger.info("사용자 정보 전송 성공", {
@@ -70,22 +72,13 @@ export class UserInfoService {
           response: response.data,
         });
         return true;
-      } else {
-        logger.warn("사용자 정보 전송 실패", {
-          userId: userInfo.userId,
-          response: response.data,
-        });
-        return false;
       }
-      */
 
-      // 시뮬레이션용 성공 응답
-      logger.info("✅ 사용자 정보 전송 완료 (시뮬레이션)", {
+      logger.warn("사용자 정보 전송 실패", {
         userId: userInfo.userId,
-        message: "사용자 정보가 성공적으로 전송되었습니다.",
+        response: response.data,
       });
-
-      return true;
+      return false;
     } catch (error) {
       logger.error("사용자 정보 전송 중 오류 발생", {
         userId: userInfo.userId,

--- a/src/services/user-info.service.ts
+++ b/src/services/user-info.service.ts
@@ -17,7 +17,6 @@ export interface UserInfo {
  */
 export class UserInfoService {
   private readonly serverUrl: string;
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   private readonly timeout: number;
 
   constructor() {

--- a/src/services/user-info.service.ts
+++ b/src/services/user-info.service.ts
@@ -1,0 +1,160 @@
+import { logger } from "../utils/logger";
+
+// 사용자 정보 인터페이스
+export interface UserInfo {
+  userId: string;
+  userName?: string;
+  userType: string;
+  utterance: string;
+  timestamp: string;
+  botId: string;
+  botName: string;
+  actionName: string;
+}
+
+/**
+ * 사용자 정보를 외부 서버로 전송하는 서비스
+ */
+export class UserInfoService {
+  private readonly serverUrl: string;
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  private readonly timeout: number;
+
+  constructor() {
+    // 환경변수에서 서버 URL과 타임아웃 설정
+    this.serverUrl = process.env.USER_INFO_SERVER_URL || "http://localhost:8080/api/users";
+    this.timeout = Number.parseInt(process.env.USER_INFO_SERVER_TIMEOUT || "5000", 10);
+  }
+
+  /**
+   * 사용자 정보를 외부 서버로 POST 요청
+   * @param userInfo 전송할 사용자 정보
+   * @returns Promise<boolean> 전송 성공 여부
+   */
+  async sendUserInfo(userInfo: UserInfo): Promise<boolean> {
+    try {
+      logger.info("사용자 정보 전송 시작", {
+        userId: userInfo.userId,
+        serverUrl: this.serverUrl,
+        userInfo: userInfo,
+      });
+
+      // 실제 서버가 없으므로 로그로만 확인
+      logger.info("📤 POST 요청 시뮬레이션", {
+        method: "POST",
+        url: this.serverUrl,
+        timeout: this.timeout,
+        headers: {
+          "Content-Type": "application/json",
+          "User-Agent": "CSmart-KakaoTalk/1.0.0",
+        },
+        body: userInfo,
+      });
+
+      // 실제 서버가 있다면 아래 코드를 사용
+      /*
+      const response: AxiosResponse<UserInfoResponse> = await axios.post(
+        this.serverUrl,
+        userInfo,
+        {
+          timeout: this.timeout,
+          headers: {
+            "Content-Type": "application/json",
+            "User-Agent": "CSmart-KakaoTalk/1.0.0",
+          },
+        }
+      );
+
+      if (response.data.success) {
+        logger.info("사용자 정보 전송 성공", {
+          userId: userInfo.userId,
+          response: response.data,
+        });
+        return true;
+      } else {
+        logger.warn("사용자 정보 전송 실패", {
+          userId: userInfo.userId,
+          response: response.data,
+        });
+        return false;
+      }
+      */
+
+      // 시뮬레이션용 성공 응답
+      logger.info("✅ 사용자 정보 전송 완료 (시뮬레이션)", {
+        userId: userInfo.userId,
+        message: "사용자 정보가 성공적으로 전송되었습니다.",
+      });
+
+      return true;
+    } catch (error) {
+      logger.error("사용자 정보 전송 중 오류 발생", {
+        userId: userInfo.userId,
+        error: error instanceof Error ? error.message : "Unknown error",
+        stack: error instanceof Error ? error.stack : undefined,
+      });
+      return false;
+    }
+  }
+
+  /**
+   * 카카오톡 챗봇 요청 데이터를 UserInfo 형식으로 변환
+   * @param chatbotData 카카오톡 챗봇 요청 데이터
+   * @returns UserInfo 변환된 사용자 정보
+   */
+  static convertFromChatbotData(chatbotData: Record<string, unknown>): UserInfo {
+    const userRequest = chatbotData.userRequest as Record<string, unknown>;
+    const user = userRequest.user as Record<string, unknown>;
+    const userProperties = user.properties as Record<string, unknown> | undefined;
+    const bot = chatbotData.bot as Record<string, unknown>;
+    const action = chatbotData.action as Record<string, unknown>;
+
+    return {
+      userId: user.id as string,
+      userName: (userProperties?.name as string) || "Unknown",
+      userType: user.type as string,
+      utterance: userRequest.utterance as string,
+      timestamp: new Date().toISOString(),
+      botId: bot.id as string,
+      botName: bot.name as string,
+      actionName: action.name as string,
+    };
+  }
+
+  /**
+   * 서버 연결 테스트
+   * @returns Promise<boolean> 연결 가능 여부
+   */
+  async testConnection(): Promise<boolean> {
+    try {
+      logger.info("서버 연결 테스트 시작", { serverUrl: this.serverUrl });
+
+      // 실제 서버가 있다면 아래 코드를 사용
+      /*
+      const response = await axios.get(`${this.serverUrl}/health`, {
+        timeout: this.timeout,
+      });
+      
+      logger.info("서버 연결 테스트 성공", {
+        serverUrl: this.serverUrl,
+        status: response.status,
+      });
+      return true;
+      */
+
+      // 시뮬레이션용 성공 응답
+      logger.info("🔗 서버 연결 테스트 성공 (시뮬레이션)", {
+        serverUrl: this.serverUrl,
+        timeout: this.timeout,
+        status: 200,
+      });
+      return true;
+    } catch (error) {
+      logger.error("서버 연결 테스트 실패", {
+        serverUrl: this.serverUrl,
+        error: error instanceof Error ? error.message : "Unknown error",
+      });
+      return false;
+    }
+  }
+}


### PR DESCRIPTION
## Feature
1. 카카오톡 전체 내용 가져오기(100개 pagination)
2. 카카오톡 메시지 보내기
3. 카카오톡 왔을 때 env에 있는 서버로 post 요청 보내기

현재 3번은 아래와 같이 폴백으로 받은 메시지 그대로 카카오톡으로 보내는 것으로 구현
추후 받아서 langgraph 가공 후 가공된 메시지로 전달 필요
<img width="459" height="249" alt="image" src="https://github.com/user-attachments/assets/23868c57-e888-4003-8a57-8ec5f92f18bb" />
